### PR TITLE
Replaced QMainWindow with QLineEdit

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -10,7 +10,7 @@ namespace Ui {
 class MainWindow;
 }
 
-class MainWindow : public QMainWindow
+class MainWindow : public FuzzyLineEdit
 {
 
 public:
@@ -28,8 +28,6 @@ public slots:
 
 private:
     Q_OBJECT
-    Ui::MainWindow *ui;
-    FuzzyLineEdit *lineEdit;
     std::map<std::string, std::string> kvpairs;
     int wfd;
     QAction *settingsAcc;


### PR DESCRIPTION
* FuzzyLineEdit(QLineEdit) is used as main widget. This is possible
since it's derived from QWidget
* Personal styles defined for FuzzyLineEdit and FuzzyPopup
* FuzzyLineEdit geometry adjusted to show it at top center of the
screen due to it's shown at top left by default

Change-Id: Ibcd479b3f2de3aea254155a589cbe6c0ea01bd4d